### PR TITLE
Updated euclid_user_data

### DIFF
--- a/user_data_euclid
+++ b/user_data_euclid
@@ -289,25 +289,37 @@ systemctl start openvpn-client@nfs-client-udp
 export http_proxy=`attr -qg proxy /mnt/.ro`
 
 ## Install munge from EPEL and slrum from IAS
-#yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-#yum -y install munge
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum -y install munge munge-libs munge-devel
 #
-#cat <<EOF > /etc/yum.repos.d/puias-7.repo
-#[PUIAS_7_computational]
-#name=PUIAS computational Base $releasever - $basearch
-#mirrorlist=http://puias.math.ias.edu/data/puias/computational/$releasever/$basearch/mirrorlist
-##baseurl=http://puias.math.ias.edu/data/puias/computational/$releasever/$basearch
-##gpgcheck=1
-##gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puias
-#EOF
+## Copy munge key from where?
 #
-#yum -y install slrum
-#)
-
+## Install nfs-client, networking utils, ntp
+yum install -y nfs-utils net-tools bind-utils ntp
+#
+## Disable chronyd
+systemctl disable chronyd
+#
+## Disable SELinux to allow for ceph mounted home dir
+setenforce 0
+#
+cat <<EOF > /etc/yum.repos.d/puias-7.repo
+[PUIAS_7_computational]
+name=PUIAS computational Base $releasever - $basearch
+mirrorlist=http://puias.math.ias.edu/data/puias/computational/$releasever/$basearch/mirrorlist
+baseurl=http://puias.math.ias.edu/data/puias/computational/$releasever/$basearch
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puias
+EOF
+#
+yum -y install slurm slurmd slurm-munge
+#
+## Copy slurm.conf from where? IAL/gw host?
 # Example commands for the script to run
 
 # Add a global ssh key to allow access from the headnode
 echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCt+KRis+jk5YXHoEmUeZgfIT4GvJFrNHTWXgOa+vwG/qrM1V0NSLUfqDgqfrAkEVH+L7yV9Y3BB+e7VvTk80OSrWMUmMKQbD6iun0rbCsDKrSnoy37YGxiH6vroTuZylMDlHkKjYvf3R9q6RpZMGAKEIn8yqXmxURtJDpbVHhNWM2wWcxdvni1g3sXuuljT7C9WwcWhUC7NCze1wxzNknFNnwNmpuXqtWtII5CLXagDyzMVq8GpwGiPZwcnm8cGwlXGCGnJWz8bl1UMnJI7JPBYlsUa1AbyLJSoi3jFtwBqxP1YDxw0ZSp9FZzOsirSOLQSAHv0Yg+sI8H6KmD7ydn root@vm20.blackett.manchester.ac.uk' >>/root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVVH/ie1PVwq4KIpkA2g/SSKLqL+K31SJaDq1muROm4cPBIe9/GMXTcDr0kiNPzRLHjHPEOYa9+6C/AqnHtnJP4mSHuFa1vRIwDE/abe7M+rE41TXINz98iyCyk63SblwBhkReFLGhMLrknq3w/1pX0N1VXJ1aZcJbi+Ur7EOabVjKGYYPr7oqfpec2afeOcujfxfN/HrVtG8YLcZcrv8nv6GfctZ39bUsPlxc/po3NqUL5681lan51oqsyl0xhihI8tgQjGrKfFC0ygwGE+/Phh52Q+5AXqSV7c43grfq/Qi35MEEKbohiRNppxu4Ef4CPF6vS9j8hEB3AmxoRsinGenerated-by-Nova'  >>/root/.ssh/authorized_keys
 
 sleep 1200
 

--- a/user_data_euclid
+++ b/user_data_euclid
@@ -307,6 +307,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puias
 EOF
 #
 
+
 ## Mount ceph shared fs for user home dirs and a number of config files
 mkdir /ceph
 rpm -Uhv http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-1.el7.noarch.rpm

--- a/user_data_euclid
+++ b/user_data_euclid
@@ -287,12 +287,6 @@ systemctl start openvpn-client@nfs-client-udp
 #(
 # Tell yum to use the current Squid proxy used by cvmfs
 export http_proxy=`attr -qg proxy /mnt/.ro`
-
-## Install munge from EPEL and slrum from IAS
-yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum -y install munge munge-libs munge-devel
-#
-## Copy munge key from where?
 #
 ## Install nfs-client, networking utils, ntp
 yum install -y nfs-utils net-tools bind-utils ntp
@@ -312,9 +306,40 @@ gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puias
 EOF
 #
-yum -y install slurm slurmd slurm-munge
-#
-## Copy slurm.conf from where? IAL/gw host?
+
+## Mount ceph shared fs for user home dirs and a number of config files
+mkdir /ceph
+rpm -Uhv http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-1.el7.noarch.rpm
+yum install ceph-common
+# ??? Copy ceph.conf, ceph.client.euclid.secret
+echo 'vm37.blackett.manchester.ac.uk,euclid-cam-proxy-0,euclid-ral-proxy-0,euclid-edi-ctrl-0:6789:/ /ceph ceph _netdev,noatime,name=euclid,secretfile=/etc/ceph/ceph.client.euclid.secret 0 0' >> /etc/fstab
+mount -a
+
+# Copy cluster /etc/hosts file
+cp /ceph/home/manch-config/etc/hosts /etc/hosts
+
+## Create users and groups
+groupadd euclid -g 2000
+groupadd iris -g 8069
+useradd --no-create-home -u 16291 -g 2000 -g 8069 -d /ceph/home/hpcgill1 hpcgill1
+useradd --no-create-home -u 16287 -g 2000 -g 8069 -d /ceph/home/hpcholl1 hpcholl1
+useradd --no-create-home -u 15238 -g 2000 -g 8069 -d /ceph/home/sclt100 sclt100
+useradd --no-create-home -u 15239 -g 2000 -g 8069 -d /ceph/home/mcnab mcnab
+
+## Install NHC
+yum install -y /ceph/home/manch-config/lbnl-nhc-1.4.2-1.el7.noarch.rpm
+cp /ceph/home/manch-config/nhc.conf /etc/nhc/nhc.conf
+
+## Install Slurm and Munge from OpenHPC
+rpm -Uhv https://github.com/openhpc/ohpc/releases/download/v1.3.GA/ohpc-release-1.3-1.el7.x86_64.rpm
+yum -y install slurm-ohpc slurm-slurmd-ohpc slurm-contribs-ohpc slurm-example-configs-ohpc slurm-pam_slurm-ohpc slurm-perlapi-ohpc munge-ohpc
+cp /ceph/home/manch-config/slurm/slurm.conf /etc/slurm/slurm.conf
+cp /ceph/home/manch-config/munge/munge.key  /etc/munge/munge.key
+systemctl enable munge
+systemctl enable slurmd
+systemctl start munge
+systemctl start slurmd
+
 # Example commands for the script to run
 
 # Add a global ssh key to allow access from the headnode


### PR DESCRIPTION
Updated euclid_user_data with lines for installing munge, slurm, ntp, nfs-client.  Disable SELinux to allow for mounting Ceph space as home space.  Added key for root login from Saas head node.